### PR TITLE
Update scf.rst

### DIFF
--- a/doc/scf.rst
+++ b/doc/scf.rst
@@ -628,7 +628,7 @@ where *K*\ :sub:`AB` is given by
 .. math::
 
    K_{AB} = \left(\frac{2\alpha\beta}{(\alpha+\beta)\pi}\right)^{\frac34}
-   \exp[-\alpha\beta\R^2_{AB}/(\alpha+\beta)]
+   \exp[-\alpha\beta/(\alpha+\beta)\cdot R^2_{AB}]
 
 Note that the norming constants of the Gaussians have been absorbed into the
 contraction coefficients already.

--- a/doc/scf.rst
+++ b/doc/scf.rst
@@ -628,7 +628,7 @@ where *K*\ :sub:`AB` is given by
 .. math::
 
    K_{AB} = \left(\frac{2\alpha\beta}{(\alpha+\beta)\pi}\right)^{\frac34}
-   \exp[-\alpha\beta/(\alpha+\beta)R^2_{AB}]
+   \exp[-\alpha\beta\R^2_{AB}/(\alpha+\beta)]
 
 Note that the norming constants of the Gaussians have been absorbed into the
 contraction coefficients already.


### PR DESCRIPTION
According to {Besalú, E., Carbó-Dorca, R. The general Gaussian product theorem. J Math Chem 49, 1769–1784 (2011)}, the R^2 should be over the fraction line which also leads for correct results for me (which makes sense since otherwise the function would be sometimes not defined). I guess it was already meant like this in the script but for some of us the original notation was rather misleading. :)
I hope the formatting is still fine, otherwise I would be thankful if you could correct it.