### PR TITLE
Added opional (bonus) DFA part for QC2

### DIFF
--- a/doc/prog-scf.rst
+++ b/doc/prog-scf.rst
@@ -915,9 +915,10 @@ an iteration. Choose *η* to get reasonably smooth, fast convergence.
 Beyond RHF
 ----------
 
-Next, we will work on extending restricted Hartree-Fock (RHF) to either 
-unrestricted Hartree-Fock (UHF) or restricted second-order Møller--Plesset 
-perturbation theory (MP2). Only one of these two exercises is mandatory.
+Next, we will work on extending restricted Hartree-Fock (RHF) to either
+unrestricted Hartree-Fock (UHF), restricted second-order Møller--Plesset
+perturbation theory (MP2) or Kohn--Sham density functional theory (DFT).
+Only one of these three exercises is mandatory.
 Note that the UHF part also includes the calculation of the spin contamination.
 
 Unrestricted Hartree-Fock
@@ -1085,3 +1086,460 @@ two-electron integrals step-by-step:
       You will find that there is a minimum in each curve. From your knowledge
       about HF and MP2, did you expect this behavior?
       What effect could be the cause for the minimum in the RHF curve?
+
+
+Kohn--Sham Density Functional Theory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Kohn--Sham DFT the exact exchange of HF is replaced by an
+exchange-correlation (XC) functional that depends on the electron density.
+Your task is to modify your RHF program into a Kohn--Sham DFT program.
+
+Recall the Hartree--Fock total energy:
+
+.. math::
+
+   E_\text{HF} = \sum_{\mu\nu} P_{\mu\nu} H_{\mu\nu}
+   + \frac{1}{2} \sum_{\mu\nu\lambda\kappa} P_{\mu\nu} P_{\lambda\kappa}
+   \left[ (\mu\nu|\kappa\lambda) - \frac{1}{2}(\mu\lambda|\kappa\nu) \right]
+   + E_\text{nuc}
+
+In Kohn--Sham DFT, the exchange term is replaced by the XC energy functional:
+
+.. math::
+
+   E_\text{KS} = \sum_{\mu\nu} P_{\mu\nu} H_{\mu\nu}
+   + \frac{1}{2} \sum_{\mu\nu\lambda\kappa} P_{\mu\nu} P_{\lambda\kappa}
+   \, (\mu\nu|\kappa\lambda)
+   + E_\text{xc}[\rho]
+   + E_\text{nuc}
+
+The Coulomb (classical electron-electron repulsion) term remains, but the
+nonlocal HF exchange term is absent. Instead, exchange is included
+approximately inside the XC energy functional, which also captures
+correlation effects. The XC energy is evaluated by numerical integration
+over the electron density on a grid.
+
+Concretely, the XC energy integral we need to evaluate is
+
+.. math::
+
+   E_\text{xc}[\rho] = \int \varepsilon_\text{xc}(\rho(\mathbf{r}))
+   \, \rho(\mathbf{r}) \,\mathrm{d}\mathbf{r}
+   \approx \sum_{g=1}^{N_\text{grid}} w_g \,
+   \varepsilon_\text{xc}(\rho_g) \, \rho_g
+
+where :math:`\mathbf{r}_g` are grid points, :math:`w_g` are the associated
+weights and :math:`\rho_g = \rho(\mathbf{r}_g)`.
+
+
+Numerical Integration
+^^^^^^^^^^^^^^^^^^^^^
+
+Analytical integration of the XC functional over all space is not possible
+for general functionals. Because of this, we use numerical quadrature.
+
+You already have a subroutine to evaluate the electron density at arbitrary
+points in space from Exercise 15. This will be an important building block here.
+
+Formally, this has to be solved:
+
+.. math::
+
+   \int f(\mathbf{r})\,\mathrm{d}\mathbf{r}
+   \approx \sum_{g=1}^{N_\text{grid}} w_g \, f(\mathbf{r}_g)
+
+where :math:`\mathbf{r}_g` are grid points and :math:`w_g` are the associated
+weights. For molecular calculations, atom-centered grids with a space
+partitioning scheme (Becke partitioning) are standard.
+
+We provide a library routine ``generate_grid`` that returns a set of grid
+points and weights for a given molecular geometry:
+
+.. code-block:: fortran
+
+   call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid)
+
+where ``xyz(3, nat)`` are the atomic positions in bohr, ``chrg(nat)`` are the
+nuclear charges, and the outputs ``grid_xyz(3, ngrid)`` and ``grid_w(ngrid)``
+are allocatable arrays of grid point coordinates and integration weights.
+Check ``src/grid.f90`` for details.
+
+
+The optional arguments ``nrad`` and ``nang`` allow overriding the default number of
+radial and angular grid points per atom.  For example, for maximum integration accuracy 
+you can use :code:`nrad = 250` and :code:`nang = 1202`; at the expense of a much higher
+computational cost.
+
+.. admonition:: Exercise 21
+
+   1. Generate a grid for your molecule using the provided ``generate_grid``
+      routine.
+   2. Evaluate the density :math:`\rho` at every grid point.
+   3. Verify that the numerical integration of the density reproduces the
+      number of electrons to reasonable accuracy.
+
+      .. math::
+
+         N_\text{el} \approx \sum_{g=1}^{N_\text{grid}} w_g \, \rho(\mathbf{r}_g)
+
+   4. Integrate two overlapping Gaussian functions on the grid and compare to the analytical result.
+      How large is the error of the numerical integration grid?
+
+Exchange-Correlation Functionals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An XC functional maps the electron density (and possibly its derivatives) to
+an energy density :math:`\varepsilon_\text{xc}`. The XC energy is then
+
+.. math::
+
+   E_\text{xc} = \int \varepsilon_\text{xc}[\rho](\mathbf{r})
+   \, \rho(\mathbf{r}) \,\mathrm{d}\mathbf{r}
+   \approx \sum_{g} w_g \, \varepsilon_\text{xc}(\rho_g) \, \rho_g
+
+To construct the Kohn--Sham potential matrix we also need the XC potential,
+which is the functional derivative of the XC energy with respect to the
+density:
+
+.. math::
+
+   v_\text{xc}(\mathbf{r}) = \frac{\delta E_\text{xc}}{\delta \rho(\mathbf{r})}
+
+For LDA, where :math:`E_\text{xc} = \int \rho\,\varepsilon_\text{xc}(\rho)\,\mathrm{d}\mathbf{r}`,
+this reduces to
+
+.. math::
+
+   v_\text{xc}^\text{LDA}(\rho) = \frac{d\left[\rho\,\varepsilon_\text{xc}(\rho)\right]}{d\rho}
+
+
+LDA: Local Density Approximation
+"""""""""""""""""""""""""""""""""
+
+The simplest class of functionals depends only on the local value of the
+density. The LDA exchange energy density (Slater exchange, also known as
+Dirac exchange) is given by
+
+.. math::
+
+   \varepsilon_\text{x}^\text{LDA}(\rho) = -\frac{3}{4}
+   \left(\frac{3}{\pi}\right)^{1/3} \rho^{1/3}
+
+and the corresponding potential by
+
+.. math::
+
+   v_\text{x}^\text{LDA}(\rho) = -\left(\frac{3}{\pi}\right)^{1/3} \rho^{1/3}
+
+For the LDA correlation we use the VWN (Vosko--Wilk--Nusair, parametrization/version 5)
+functional. The VWN correlation energy density is given in terms of a function
+of the Wigner--Seitz radius :math:`r_s`:
+
+.. math::
+
+   r_s = \left(\frac{3}{4\pi\rho}\right)^{1/3}
+
+.. math::
+
+   \varepsilon_\text{c}^\text{VWN}(r_s) = \frac{A}{2}\left\{
+   \ln\frac{x^2}{X(x)}
+   + \frac{2b}{Q}\arctan\frac{Q}{2x+b}
+   - \frac{bx_0}{X(x_0)}\left[
+   \ln\frac{(x-x_0)^2}{X(x)} + \frac{2(b+2x_0)}{Q}\arctan\frac{Q}{2x+b}
+   \right]\right\}
+
+where :math:`x = r_s^{1/2}`,
+:math:`X(x) = x^2 + bx + c`,
+:math:`Q = (4c - b^2)^{1/2}`
+and the VWN-V parameters are
+:math:`A = 0.0621814`, :math:`b = 3.72744`, :math:`c = 12.9352`, :math:`x_0 = -0.10498`.
+
+The VWN potential :math:`v_\text{c}` is obtained by
+
+.. math::
+
+   v_\text{c}^\text{VWN} = \varepsilon_\text{c}^\text{VWN}(r_s)
+   - \frac{r_s}{3}\frac{\partial\varepsilon_\text{c}^\text{VWN}}{\partial r_s}
+
+.. admonition:: Exercise 22
+
+   1. Write a ``subroutine`` that computes the LDA exchange energy density
+      :math:`\varepsilon_\text{x}` for a given density :math:`\rho`.
+   2. Extend this ``subroutine`` to compute the LDA exchange potential
+      :math:`v_\text{x}` for a given density :math:`\rho`.
+   3. The implementation for the VWN correlation energy density and potential
+      is supplied inside ``src/xc.f90``. Combine that with your LDA exchange
+      implementation to get the total LDA XC energy density and potential.
+   4. Verify your implementations against the following reference values
+      (from the libxc density functional library):
+
+      .. list-table::
+         :header-rows: 1
+         :widths: 15 40 40
+
+         * - :math:`\rho`
+           - :math:`\varepsilon_\text{x}\;(E_\text{h})`
+           - :math:`v_\text{x}\;(E_\text{h})`
+         * - :math:`0.176`
+           - :math:`-0.413894142281`
+           - :math:`-0.551858856374`
+         * - :math:`0.300`
+           - :math:`-0.494415573787`
+           - :math:`-0.659220765051`
+         * - :math:`0.520`
+           - :math:`-0.593908451244`
+           - :math:`-0.791877934993`
+         * - :math:`3.400`
+           - :math:`-1.110566825988`
+           - :math:`-1.480755767980`
+
+.. hint::
+
+   Be careful with the case :math:`\rho = 0`. Your functional routines should return
+   zero for vanishing density without causing division by zero.
+
+
+PBE: Generalized Gradient Approximation
+""""""""""""""""""""""""""""""""""""""""
+
+Generalized gradient approximation (GGA) functionals also depend on the
+gradient of the density. This introduces an additional quantity, the reduced
+density gradient:
+
+.. math::
+
+   s = \frac{|\nabla\rho|}{2(3\pi^2)^{1/3}\rho^{4/3}}
+
+For the density gradient you need to evaluate the gradient of each basis
+function at the grid points. For :math:`s`-type Gaussian basis functions
+the gradient is straightforward:
+
+.. math::
+
+   \nabla\psi_\mu(\mathbf{r}) = -2\alpha(\mathbf{r} - \mathbf{R}_A)
+   \,\psi_\mu(\mathbf{r})
+
+where :math:`\alpha` is the exponent and :math:`\mathbf{R}_A` the center of the basis function.
+For contracted functions, this gradient is a linear combination over primitives
+weighted by the contraction coefficients.
+
+The gradient of the density is then
+
+.. math::
+
+   \nabla\rho(\mathbf{r}) = 2\sum_{\mu}\sum_{\nu} P_{\mu\nu}\,
+   \nabla\psi_\mu(\mathbf{r})\,\psi_\nu(\mathbf{r})
+
+where the factor of 2 exploits the symmetry in :math:`\mu` and :math:`\nu`.
+
+The PBE exchange enhancement factor is
+
+.. math::
+
+   F_\text{x}^\text{PBE}(s) = 1 + \kappa
+   - \frac{\kappa}{1 + \mu s^2 / \kappa}
+
+with :math:`\kappa = 0.804` and :math:`\mu = 0.21951`. The PBE exchange energy density is then
+
+.. math::
+
+   \varepsilon_\text{x}^\text{PBE}(\rho, s) =
+   \varepsilon_\text{x}^\text{LDA}(\rho) \cdot F_\text{x}^\text{PBE}(s)
+
+The PBE correlation builds on the LDA correlation (specifically the
+Perdew--Wang 1992 parametrization). The PBE correlation energy density is
+
+.. math::
+
+   \varepsilon_\text{c}^\text{PBE}(\rho, s) =
+   \varepsilon_\text{c}^\text{LDA}(\rho) + H(r_s, t)
+
+where :math:`t = |\nabla\rho| / (2 k_s \rho)` with
+:math:`k_s = (4 k_F / \pi)^{1/2}` and
+:math:`k_F = (3\pi^2 \rho)^{1/3}`, and
+
+.. math::
+
+   H = \gamma\,\ln\left\{1 + \frac{\beta}{\gamma}\,t^2\,
+   \frac{1 + At^2}{1 + At^2 + A^2t^4}\right\}
+
+with :math:`\gamma = (1 - \ln 2) / \pi^2`, :math:`\beta = 0.066725` (in atomic units) and
+
+.. math::
+
+   A = \frac{\beta}{\gamma}\left[\exp\!\left(
+   -\varepsilon_\text{c}^\text{LDA}/\gamma\right) - 1\right]^{-1}
+
+Note that the standard PBE functional consists of PBE exchange *and* PBE
+correlation — it is *not* a combination of PBE exchange with VWN correlation.
+VWN5 is an LDA correlation functional.  In summary:
+
+- **LDA** = Slater exchange + VWN5 correlation
+- **PBE** = PBE exchange + PBE correlation
+
+Both PBE exchange and PBE correlation are provided in ``src/xc.f90``.
+
+For GGA functionals it is convenient to define the XC energy integrand
+
+.. math::
+
+   f(\rho, \sigma) = \rho\,\varepsilon_\text{xc}(\rho, \sigma),
+   \qquad \sigma = |\nabla\rho|^2
+
+The XC potential contribution to the Kohn--Sham matrix then has an additional
+term involving the density gradient:
+
+.. math::
+
+   (V_\text{xc})_{\mu\nu} = \sum_g w_g \left[
+   \frac{\partial f}{\partial\rho}\,
+   \psi_\mu(\mathbf{r}_g)\,\psi_\nu(\mathbf{r}_g)
+   + 2\,\frac{\partial f}{\partial\sigma}\,
+   \nabla\rho(\mathbf{r}_g)\cdot
+   \left(\nabla\psi_\mu(\mathbf{r}_g)\,\psi_\nu(\mathbf{r}_g)
+   + \psi_\mu(\mathbf{r}_g)\,\nabla\psi_\nu(\mathbf{r}_g)\right)
+   \right]
+
+The routines ``pbe_exchange`` and ``pbe_correlation`` in ``src/xc.f90`` return
+exactly these derivatives: ``vrho`` = :math:`\partial f/\partial\rho` and
+``vsigma`` = :math:`\partial f/\partial\sigma`.
+
+.. admonition:: Exercise 23
+
+   1. Code a ``subroutine`` that evaluates the gradient of each basis function
+      :math:`\nabla\psi_\mu(\mathbf{r})` at a given grid point.
+   2. Use it together with the density matrix to compute the density gradient
+      :math:`\nabla\rho(\mathbf{r})` and the reduced density gradient :math:`s` on the
+      grid.
+   3. Verify your gradient implementation:
+      - Check that the numerical integral :math:`\int|\nabla\rho|^2\,\mathrm{d}\mathbf{r}`
+      gives a physically reasonable result.
+      - Compare the  analytical gradient with a finite-difference (numerical) 
+      approximation at selected grid points.
+
+Building the Kohn--Sham Matrix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Kohn--Sham (KS) matrix replaces the Fock matrix in the SCF procedure.
+Instead of the HF exchange, we have a DFA XC contribution:
+
+.. math::
+
+   F_{\mu\nu}^\text{KS} = H_{\mu\nu}
+   + \sum_\lambda \sum_\kappa P_{\lambda\kappa}
+   \left(\mu\nu|\kappa\lambda\right)
+   + (V_\text{xc})_{\mu\nu}
+
+Note the absence of the exchange term
+:math:`P_{\lambda\kappa}(\mu\lambda|\kappa\nu)` compared to HF.
+For LDA, the XC matrix elements are computed by numerical integration:
+
+.. math::
+
+   (V_\text{xc})_{\mu\nu} = \sum_{g=1}^{N_\text{grid}} w_g \,
+   v_\text{xc}(\rho(\mathbf{r}_g)) \, \psi_\mu(\mathbf{r}_g) \,
+   \psi_\nu(\mathbf{r}_g)
+
+The total Kohn--Sham energy is
+
+.. math::
+
+   E_\text{KS} = \sum_{\mu\nu} P_{\mu\nu} H_{\mu\nu}
+   + \frac{1}{2} \sum_{\mu\nu} P_{\mu\nu} J_{\mu\nu}
+   + E_\text{xc}
+   + E_\text{nuc}
+
+where :math:`\mathbf{J}` is the Coulomb matrix, i.e.
+:math:`J_{\mu\nu} = \sum_{\lambda\kappa} P_{\lambda\kappa}(\mu\nu|\kappa\lambda)`.
+
+.. admonition:: Exercise 24
+
+   1. Copy your RHF subroutine and modify it into a Kohn--Sham DFT
+      subroutine. Remove the exchange term from the Fock matrix construction
+      and replace it with the DFA XC potential matrix.
+   2. Build the LDA XC potential :math:`(V_\text{xc})_{\mu\nu}` by looping
+      over all grid points. At each grid point, evaluate the density,
+      the XC potential and all basis function values.
+   3. Implement the Kohn--Sham energy expression.
+   4. Run LDA (Slater + VWN5) calculations using the STO-3G basis set and
+      compare your results (see the table below).
+   5. Extend your KS subroutine to support GGA functionals.
+      Use the ``pbe_exchange`` and ``pbe_correlation`` routines from
+      ``src/xc.f90`` — they return ``vrho`` (= :math:`\partial f/\partial\rho`) and
+      ``vsigma`` (= :math:`\partial f/\partial\sigma`).
+      Build the GGA XC matrix using the formula given above.
+   6. Run PBE (PBE exchange + PBE correlation) calculations for the same
+      systems and compare with LDA and the results from table.
+   7. Calculate the dissociation curve of :math:`\text{H}_2` with LDA and PBE.
+      Plot the DFT curves together with the RHF curve on a relative energy
+      scale (in kcal/mol).
+      How does DFT describe the dissociation compared to RHF?
+
+
+   Reference energies (ORCA 6.1, STO-3G basis):
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 15 28 28 28
+
+      * - Input
+        - :math:`E_\text{LDA}\;(E_\text{h})`
+        - :math:`E_\text{PBE}\;(E_\text{h})`
+        - :math:`E_\text{PBE0}\;(E_\text{h})`
+      * - :math:`\text{H}_2`
+        - :math:`-1.121201`
+        - :math:`-1.152066`
+        - :math:`-1.154312`
+      * - He
+        - :math:`-2.771886`
+        - :math:`-2.830171`
+        - :math:`-2.835986`
+      * - Be
+        - :math:`-14.221142`
+        - :math:`-14.405935`
+        - :math:`-14.415201`
+      * - LiH
+        - :math:`-7.791016`
+        - :math:`-7.919654`
+        - :math:`-7.926304`
+
+Beyond Semi-Local Functionals (Bonus)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+LDA and GGA functionals depend only on the local density and its gradient.
+A natural next step is to mix in a fraction of exact (Hartree--Fock) exchange.
+These *hybrid* functionals construct the XC energy as
+
+.. math::
+
+   E_\text{xc}^\text{hybrid} = a\,E_\text{x}^\text{HF}
+   + (1 - a)\,E_\text{x}^\text{DFA} + E_\text{c}^\text{DFA}
+
+where :math:`a` is the mixing parameter and DFA denotes the chosen
+density functional approximation.
+The most widely used hybrid is PBE0, which combines 25% HF exchange with
+75% PBE exchange and full PBE correlation (:math:`a = 0.25`).
+
+In practice this means the Kohn--Sham matrix becomes
+
+.. math::
+
+   F_{\mu\nu}^\text{hybrid} = H_{\mu\nu}
+   + \sum_{\lambda\kappa} P_{\lambda\kappa}\,(\mu\nu|\kappa\lambda)
+   - \frac{a}{2}\sum_{\lambda\kappa} P_{\lambda\kappa}\,(\mu\lambda|\kappa\nu)
+   + (V_\text{xc}^\text{DFA})_{\mu\nu}
+
+Note that a fraction of the HF exchange integral reappears — you can reuse
+your existing exchange code, scaled by :math:`a`.
+The DFA XC potential matrix :math:`(V_\text{xc}^\text{DFA})_{\mu\nu}` is
+built exactly as before, but using :math:`(1-a)` times the DFA exchange
+contribution.
+
+.. admonition:: Exercise 25 (Bonus)
+
+   1. Implement PBE0 by combining your PBE KS routine with a fraction
+      :math:`a = 0.25` of HF exchange.
+   2. Run PBE0 calculations for the reference systems and compare with
+      the PBE0 column in the table above.
+   3. How do the PBE0 energies compare to pure PBE and LDA?

--- a/scf/makefile
+++ b/scf/makefile
@@ -13,7 +13,9 @@ SRCS += integrals.f90\
         prog.f90\
         print_matrix.f90\
         linear_algebra.f90\
-        io_tools.f90
+        io_tools.f90\
+        grid.f90\
+        xc.f90
 
 # make object files from source names
 OBJS := $(patsubst %, build/%.o, $(SRCS))
@@ -64,7 +66,9 @@ $(BUILD)/main.f90.o: $(BUILD)/integrals.f90.o\
                      $(BUILD)/slater.f90.o\
                      $(BUILD)/print_matrix.f90.o\
                      $(BUILD)/linear_algebra.f90.o\
-                     $(BUILD)/io_tools.f90.o
+                     $(BUILD)/io_tools.f90.o\
+                     $(BUILD)/grid.f90.o\
+                     $(BUILD)/xc.f90.o
 $(BUILD)/prog.f90.o: $(BUILD)/main.f90.o
 
 .PHONY: setup clean veryclean

--- a/scf/src/grid.f90
+++ b/scf/src/grid.f90
@@ -1,0 +1,582 @@
+module grid
+    implicit none
+
+    private
+    public :: generate_grid
+
+    integer, parameter :: wp = selected_real_kind(15)
+
+    real(wp), parameter :: pi = 4.0_wp*atan(1.0_wp)
+
+    !> covalent radii in bohr (H-Zn), used for Becke partitioning
+    !! and radial grid scaling
+    real(wp), parameter :: cov_rad(30) = [ &
+                           0.59_wp, 0.53_wp, &
+                           2.42_wp, 1.81_wp, &
+                           1.59_wp, 1.38_wp, 1.34_wp, 1.25_wp, 1.08_wp, 1.10_wp, &
+                           3.14_wp, 2.66_wp, &
+                           2.29_wp, 2.10_wp, 2.02_wp, 1.98_wp, 1.93_wp, 2.00_wp, &
+                           3.84_wp, 3.33_wp, 3.21_wp, 3.02_wp, 2.89_wp, 2.63_wp, &
+                           2.83_wp, 2.68_wp, 2.61_wp, 2.34_wp, 2.49_wp, 2.31_wp]
+
+contains
+
+!> generate a molecular integration grid using atom-centered
+!! Chebyshev-Lebedev quadrature with Becke partitioning
+!!
+!! returns allocatable arrays of grid points and weights
+    subroutine generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid, nrad, nang)
+
+        !> atomic coordinates in bohr, shape (3, nat)
+        real(wp), intent(in) :: xyz(:, :)
+        !> nuclear charges (used to determine element type)
+        real(wp), intent(in) :: chrg(:)
+        !> grid point coordinates, shape (3, ngrid)
+        real(wp), allocatable, intent(out) :: grid_xyz(:, :)
+        !> grid point weights, shape (ngrid)
+        real(wp), allocatable, intent(out) :: grid_w(:)
+        !> total number of grid points
+        integer, intent(out) :: ngrid
+        !> optional: number of radial grid points (overrides element-based default)
+        integer, optional, intent(in) :: nrad
+        !> optional: number of angular grid points, must be 230 or 434
+    !! (overrides element-based default)
+        integer, optional, intent(in) :: nang
+
+        integer :: nat, iat, iz, nr, nl, ir, il, ig, max_pts
+        real(wp) :: p, x_i
+        real(wp) :: spacew
+        real(wp), allocatable :: radii(:), rad_w(:)
+        real(wp), allocatable :: lx(:), ly(:), lz(:), lw(:)
+        real(wp), allocatable :: tmp_xyz(:, :), tmp_w(:)
+        real(wp) :: point(3)
+        integer :: nl2
+
+        nat = size(chrg)
+
+        ! estimate maximum grid size: sum over atoms of nr*nl
+        max_pts = 0
+        do iat = 1, nat
+            iz = nint(chrg(iat))
+            call grid_sizes(iz, nr, nl)
+            if (present(nrad)) nr = nrad
+            if (present(nang)) nl = nang
+            max_pts = max_pts + nr*nl
+        end do
+
+        allocate (tmp_xyz(3, max_pts), tmp_w(max_pts))
+
+        ig = 0
+        do iat = 1, nat
+            iz = nint(chrg(iat))
+            call grid_sizes(iz, nr, nl)
+            if (present(nrad)) nr = nrad
+            if (present(nang)) nl = nang
+
+            ! radial grid scaling parameter
+            if (iz == 1) then
+                p = cov_rad(iz)
+            else
+                p = cov_rad(iz)*0.5_wp
+            end if
+
+            ! compute radial grid (2nd Chebyshev)
+            allocate (radii(nr), rad_w(nr))
+            do ir = 1, nr
+                x_i = cos(ir*pi/real(nr + 1, wp))
+                radii(ir) = (1.0_wp + x_i)/(1.0_wp - x_i)*p
+                rad_w(ir) = (2.0_wp*pi/real(nr + 1, wp)) &
+                           & *p**3*((x_i + 1.0_wp)**2.5_wp/(1.0_wp - x_i)**3.5_wp)
+            end do
+
+            ! compute angular grid (Lebedev)
+            allocate (lx(nl), ly(nl), lz(nl), lw(nl))
+            nl2 = 0
+            if (nl == 230) then
+                call LD0230(lx, ly, lz, lw, nl2)
+            else if (nl == 434) then
+                call LD0434(lx, ly, lz, lw, nl2)
+            else
+                call LD1202(lx, ly, lz, lw, nl2)
+            end if
+            lw = lw*4.0_wp*pi
+
+            ! combine radial and angular grids, shift to atom center,
+            ! and apply Becke partitioning
+            do ir = 1, nr
+                do il = 1, nl
+                    ig = ig + 1
+                    tmp_xyz(1, ig) = radii(ir)*lx(il) + xyz(1, iat)
+                    tmp_xyz(2, ig) = radii(ir)*ly(il) + xyz(2, iat)
+                    tmp_xyz(3, ig) = radii(ir)*lz(il) + xyz(3, iat)
+                    tmp_w(ig) = rad_w(ir)*lw(il)
+
+                    ! apply Becke space partitioning weight
+                    point = tmp_xyz(:, ig)
+                    call becke_weight(point, iat, nat, xyz, chrg, spacew)
+                    tmp_w(ig) = tmp_w(ig)*spacew
+                end do
+            end do
+
+            deallocate (radii, rad_w, lx, ly, lz, lw)
+        end do
+
+        ngrid = ig
+        allocate (grid_xyz(3, ngrid), grid_w(ngrid))
+        grid_xyz(:, 1:ngrid) = tmp_xyz(:, 1:ngrid)
+        grid_w(1:ngrid) = tmp_w(1:ngrid)
+        deallocate (tmp_xyz, tmp_w)
+
+    end subroutine generate_grid
+
+!> determine number of radial and angular grid points based on element
+    pure subroutine grid_sizes(iz, nr, nl)
+        integer, intent(in) :: iz
+        integer, intent(out) :: nr, nl
+
+        if (iz <= 2) then
+            nr = 35; nl = 230
+        else if (iz <= 10) then
+            nr = 65; nl = 434
+        else if (iz <= 18) then
+            nr = 80; nl = 434
+        else
+            nr = 100; nl = 434
+        end if
+    end subroutine grid_sizes
+
+!> Becke fuzzy partitioning weight for a point assigned to atom `iat`
+    pure subroutine becke_weight(point, iat, nat, xyz, chrg, weight)
+        real(wp), intent(in) :: point(3)
+        integer, intent(in) :: iat, nat
+        real(wp), intent(in) :: xyz(3, nat)
+        real(wp), intent(in) :: chrg(nat)
+        real(wp), intent(out) :: weight
+
+        real(wp) :: weights(nat)
+        real(wp) :: ri, rj, rij, chi, mu_prime, a_adj, mu, nu, s
+        integer :: ii, jj, izi, izj
+
+        weights = 1.0_wp
+        do ii = 1, nat
+            izi = nint(chrg(ii))
+            ri = sqrt(sum((point - xyz(:, ii))**2))
+            do jj = 1, nat
+                if (jj == ii) cycle
+                izj = nint(chrg(jj))
+                rj = sqrt(sum((point - xyz(:, jj))**2))
+                rij = sqrt(sum((xyz(:, ii) - xyz(:, jj))**2))
+                mu = (ri - rj)/rij
+                ! size-adjusted Becke partitioning using covalent radii
+                chi = cov_rad(izi)/cov_rad(izj)
+                mu_prime = (chi - 1.0_wp)/(chi + 1.0_wp)
+                a_adj = mu_prime/(mu_prime**2 - 1.0_wp)
+                if (a_adj > 0.5_wp) a_adj = 0.5_wp
+                if (a_adj < -0.5_wp) a_adj = -0.5_wp
+                nu = mu + a_adj*(1.0_wp - mu**2)
+                s = 0.5_wp*(1.0_wp - becke_mu(nu, 3))
+                weights(ii) = weights(ii)*s
+            end do
+        end do
+        weight = weights(iat)/sum(weights)
+    end subroutine becke_weight
+
+!> iterated Becke smoothing function: f(x) = 1.5*x - 0.5*x^3, applied p times
+    pure recursive function becke_mu(x, p) result(y)
+        real(wp), intent(in) :: x
+        integer, intent(in) :: p
+        real(wp) :: y
+
+        if (p <= 1) then
+            y = 1.5_wp*x - 0.5_wp*x**3
+        else
+            y = 1.5_wp*becke_mu(x, p - 1) - 0.5_wp*becke_mu(x, p - 1)**3
+        end if
+    end function becke_mu
+
+! ============================================================
+! Lebedev angular quadrature rules
+! Based on code by Christoph van Wuellen (modified by Dirac4pi)
+! ============================================================
+
+!> core symmetry generator for Lebedev grid
+    pure subroutine gen_oh(code, num, x, y, z, w, a, b, v)
+        integer, intent(in) :: code
+        integer, intent(inout) :: num
+        double precision, intent(inout) :: x(:), y(:), z(:), w(:)
+        double precision, intent(inout) :: a, b, v
+        double precision :: c
+
+        select case (code)
+        case (1)
+            a = 1.0d0
+            x(1) = a; y(1) = 0.0d0; z(1) = 0.0d0; w(1) = v
+            x(2) = -a; y(2) = 0.0d0; z(2) = 0.0d0; w(2) = v
+            x(3) = 0.0d0; y(3) = a; z(3) = 0.0d0; w(3) = v
+            x(4) = 0.0d0; y(4) = -a; z(4) = 0.0d0; w(4) = v
+            x(5) = 0.0d0; y(5) = 0.0d0; z(5) = a; w(5) = v
+            x(6) = 0.0d0; y(6) = 0.0d0; z(6) = -a; w(6) = v
+            num = num + 6
+        case (2)
+            a = sqrt(0.5d0)
+            x(1) = 0.0d0; y(1) = a; z(1) = a; w(1) = v
+            x(2) = 0.0d0; y(2) = -a; z(2) = a; w(2) = v
+            x(3) = 0.0d0; y(3) = a; z(3) = -a; w(3) = v
+            x(4) = 0.0d0; y(4) = -a; z(4) = -a; w(4) = v
+            x(5) = a; y(5) = 0.0d0; z(5) = a; w(5) = v
+            x(6) = -a; y(6) = 0.0d0; z(6) = a; w(6) = v
+            x(7) = a; y(7) = 0.0d0; z(7) = -a; w(7) = v
+            x(8) = -a; y(8) = 0.0d0; z(8) = -a; w(8) = v
+            x(9) = a; y(9) = a; z(9) = 0.0d0; w(9) = v
+            x(10) = -a; y(10) = a; z(10) = 0.0d0; w(10) = v
+            x(11) = a; y(11) = -a; z(11) = 0.0d0; w(11) = v
+            x(12) = -a; y(12) = -a; z(12) = 0.0d0; w(12) = v
+            num = num + 12
+        case (3)
+            a = sqrt(1.0d0/3.0d0)
+            x(1) = a; y(1) = a; z(1) = a; w(1) = v
+            x(2) = -a; y(2) = a; z(2) = a; w(2) = v
+            x(3) = a; y(3) = -a; z(3) = a; w(3) = v
+            x(4) = -a; y(4) = -a; z(4) = a; w(4) = v
+            x(5) = a; y(5) = a; z(5) = -a; w(5) = v
+            x(6) = -a; y(6) = a; z(6) = -a; w(6) = v
+            x(7) = a; y(7) = -a; z(7) = -a; w(7) = v
+            x(8) = -a; y(8) = -a; z(8) = -a; w(8) = v
+            num = num + 8
+        case (4)
+            b = sqrt(1.0d0 - 2.0d0*a*a)
+            x(1) = a; y(1) = a; z(1) = b; w(1) = v
+            x(2) = -a; y(2) = a; z(2) = b; w(2) = v
+            x(3) = a; y(3) = -a; z(3) = b; w(3) = v
+            x(4) = -a; y(4) = -a; z(4) = b; w(4) = v
+            x(5) = a; y(5) = a; z(5) = -b; w(5) = v
+            x(6) = -a; y(6) = a; z(6) = -b; w(6) = v
+            x(7) = a; y(7) = -a; z(7) = -b; w(7) = v
+            x(8) = -a; y(8) = -a; z(8) = -b; w(8) = v
+            x(9) = a; y(9) = b; z(9) = a; w(9) = v
+            x(10) = -a; y(10) = b; z(10) = a; w(10) = v
+            x(11) = a; y(11) = -b; z(11) = a; w(11) = v
+            x(12) = -a; y(12) = -b; z(12) = a; w(12) = v
+            x(13) = a; y(13) = b; z(13) = -a; w(13) = v
+            x(14) = -a; y(14) = b; z(14) = -a; w(14) = v
+            x(15) = a; y(15) = -b; z(15) = -a; w(15) = v
+            x(16) = -a; y(16) = -b; z(16) = -a; w(16) = v
+            x(17) = b; y(17) = a; z(17) = a; w(17) = v
+            x(18) = -b; y(18) = a; z(18) = a; w(18) = v
+            x(19) = b; y(19) = -a; z(19) = a; w(19) = v
+            x(20) = -b; y(20) = -a; z(20) = a; w(20) = v
+            x(21) = b; y(21) = a; z(21) = -a; w(21) = v
+            x(22) = -b; y(22) = a; z(22) = -a; w(22) = v
+            x(23) = b; y(23) = -a; z(23) = -a; w(23) = v
+            x(24) = -b; y(24) = -a; z(24) = -a; w(24) = v
+            num = num + 24
+        case (5)
+            b = sqrt(1.0d0 - a*a)
+            x(1) = a; y(1) = b; z(1) = 0.0d0; w(1) = v
+            x(2) = -a; y(2) = b; z(2) = 0.0d0; w(2) = v
+            x(3) = a; y(3) = -b; z(3) = 0.0d0; w(3) = v
+            x(4) = -a; y(4) = -b; z(4) = 0.0d0; w(4) = v
+            x(5) = b; y(5) = a; z(5) = 0.0d0; w(5) = v
+            x(6) = -b; y(6) = a; z(6) = 0.0d0; w(6) = v
+            x(7) = b; y(7) = -a; z(7) = 0.0d0; w(7) = v
+            x(8) = -b; y(8) = -a; z(8) = 0.0d0; w(8) = v
+            x(9) = a; y(9) = 0.0d0; z(9) = b; w(9) = v
+            x(10) = -a; y(10) = 0.0d0; z(10) = b; w(10) = v
+            x(11) = a; y(11) = 0.0d0; z(11) = -b; w(11) = v
+            x(12) = -a; y(12) = 0.0d0; z(12) = -b; w(12) = v
+            x(13) = b; y(13) = 0.0d0; z(13) = a; w(13) = v
+            x(14) = -b; y(14) = 0.0d0; z(14) = a; w(14) = v
+            x(15) = b; y(15) = 0.0d0; z(15) = -a; w(15) = v
+            x(16) = -b; y(16) = 0.0d0; z(16) = -a; w(16) = v
+            x(17) = 0.0d0; y(17) = a; z(17) = b; w(17) = v
+            x(18) = 0.0d0; y(18) = -a; z(18) = b; w(18) = v
+            x(19) = 0.0d0; y(19) = a; z(19) = -b; w(19) = v
+            x(20) = 0.0d0; y(20) = -a; z(20) = -b; w(20) = v
+            x(21) = 0.0d0; y(21) = b; z(21) = a; w(21) = v
+            x(22) = 0.0d0; y(22) = -b; z(22) = a; w(22) = v
+            x(23) = 0.0d0; y(23) = b; z(23) = -a; w(23) = v
+            x(24) = 0.0d0; y(24) = -b; z(24) = -a; w(24) = v
+            num = num + 24
+        case (6)
+            c = sqrt(1.0d0 - a*a - b*b)
+            x(1) = a; y(1) = b; z(1) = c; w(1) = v
+            x(2) = -a; y(2) = b; z(2) = c; w(2) = v
+            x(3) = a; y(3) = -b; z(3) = c; w(3) = v
+            x(4) = -a; y(4) = -b; z(4) = c; w(4) = v
+            x(5) = a; y(5) = b; z(5) = -c; w(5) = v
+            x(6) = -a; y(6) = b; z(6) = -c; w(6) = v
+            x(7) = a; y(7) = -b; z(7) = -c; w(7) = v
+            x(8) = -a; y(8) = -b; z(8) = -c; w(8) = v
+            x(9) = a; y(9) = c; z(9) = b; w(9) = v
+            x(10) = -a; y(10) = c; z(10) = b; w(10) = v
+            x(11) = a; y(11) = -c; z(11) = b; w(11) = v
+            x(12) = -a; y(12) = -c; z(12) = b; w(12) = v
+            x(13) = a; y(13) = c; z(13) = -b; w(13) = v
+            x(14) = -a; y(14) = c; z(14) = -b; w(14) = v
+            x(15) = a; y(15) = -c; z(15) = -b; w(15) = v
+            x(16) = -a; y(16) = -c; z(16) = -b; w(16) = v
+            x(17) = b; y(17) = a; z(17) = c; w(17) = v
+            x(18) = -b; y(18) = a; z(18) = c; w(18) = v
+            x(19) = b; y(19) = -a; z(19) = c; w(19) = v
+            x(20) = -b; y(20) = -a; z(20) = c; w(20) = v
+            x(21) = b; y(21) = a; z(21) = -c; w(21) = v
+            x(22) = -b; y(22) = a; z(22) = -c; w(22) = v
+            x(23) = b; y(23) = -a; z(23) = -c; w(23) = v
+            x(24) = -b; y(24) = -a; z(24) = -c; w(24) = v
+            x(25) = b; y(25) = c; z(25) = a; w(25) = v
+            x(26) = -b; y(26) = c; z(26) = a; w(26) = v
+            x(27) = b; y(27) = -c; z(27) = a; w(27) = v
+            x(28) = -b; y(28) = -c; z(28) = a; w(28) = v
+            x(29) = b; y(29) = c; z(29) = -a; w(29) = v
+            x(30) = -b; y(30) = c; z(30) = -a; w(30) = v
+            x(31) = b; y(31) = -c; z(31) = -a; w(31) = v
+            x(32) = -b; y(32) = -c; z(32) = -a; w(32) = v
+            x(33) = c; y(33) = a; z(33) = b; w(33) = v
+            x(34) = -c; y(34) = a; z(34) = b; w(34) = v
+            x(35) = c; y(35) = -a; z(35) = b; w(35) = v
+            x(36) = -c; y(36) = -a; z(36) = b; w(36) = v
+            x(37) = c; y(37) = a; z(37) = -b; w(37) = v
+            x(38) = -c; y(38) = a; z(38) = -b; w(38) = v
+            x(39) = c; y(39) = -a; z(39) = -b; w(39) = v
+            x(40) = -c; y(40) = -a; z(40) = -b; w(40) = v
+            x(41) = c; y(41) = b; z(41) = a; w(41) = v
+            x(42) = -c; y(42) = b; z(42) = a; w(42) = v
+            x(43) = c; y(43) = -b; z(43) = a; w(43) = v
+            x(44) = -c; y(44) = -b; z(44) = a; w(44) = v
+            x(45) = c; y(45) = b; z(45) = -a; w(45) = v
+            x(46) = -c; y(46) = b; z(46) = -a; w(46) = v
+            x(47) = c; y(47) = -b; z(47) = -a; w(47) = v
+            x(48) = -c; y(48) = -b; z(48) = -a; w(48) = v
+            num = num + 48
+        end select
+    end subroutine gen_oh
+
+!> generate 230 grid points in Lebedev scheme
+    pure subroutine LD0230(x, y, z, w, n)
+        double precision, intent(out) :: x(:), y(:), z(:), w(:)
+        integer, intent(out) :: n
+        double precision :: a, b, v
+
+        n = 1
+        v = -0.5522639919727325d-1
+        call gen_oh(1, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        v = 0.4450274607445226d-2
+        call gen_oh(3, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4492044687397611d+0
+        v = 0.4496841067921404d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2520419490210201d+0
+        v = 0.5049153450478750d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6981906658447242d+0
+        v = 0.3976408018051883d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6587405243460960d+0
+        v = 0.4401400650381014d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4038544050097660d-1
+        v = 0.1724544350544401d-1
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.5823842309715585d+0
+        v = 0.4231083095357343d-2
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.3545877390518688d+0
+        v = 0.5198069864064399d-2
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2272181808998187d+0
+        b = 0.4864661535886647d+0
+        v = 0.4695720972568883d-2
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        n = n - 1
+    end subroutine LD0230
+
+!> generate 434 grid points in Lebedev scheme
+    pure subroutine LD0434(x, y, z, w, n)
+        double precision, intent(out) :: x(:), y(:), z(:), w(:)
+        integer, intent(out) :: n
+        double precision :: a, b, v
+
+        n = 1
+        v = 0.5265897968224436d-3
+        call gen_oh(1, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        v = 0.2548219972002607d-2
+        call gen_oh(2, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        v = 0.2512317418927307d-2
+        call gen_oh(3, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6909346307509111d+0
+        v = 0.2530403801186355d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.1774836054609158d+0
+        v = 0.2014279020918528d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4914342637784746d+0
+        v = 0.2501725168402936d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6456664707424256d+0
+        v = 0.2513267174597564d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2861289010307638d+0
+        v = 0.2302694782227416d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7568084367178018d-1
+        v = 0.1462495621594614d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.3927259763368002d+0
+        v = 0.2445373437312980d-2
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8818132877794288d+0
+        v = 0.2417442375638981d-2
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9776428111182649d+0
+        v = 0.1910951282179532d-2
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2054823696403044d+0
+        b = 0.8689460322872412d+0
+        v = 0.2416930044324775d-2
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.5905157048925271d+0
+        b = 0.7999278543857286d+0
+        v = 0.2512236854563495d-2
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.5550152361076807d+0
+        b = 0.7717462626915901d+0
+        v = 0.2496644054553086d-2
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9371809858553722d+0
+        b = 0.3344363145343455d+0
+        v = 0.2236607760437849d-2
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        n = n - 1
+    end subroutine LD0434
+
+    pure subroutine LD1202(x, y, z, w, n)
+        double precision, intent(out) :: x(:), y(:), z(:), w(:)
+        integer, intent(out) :: n
+        double precision :: a, b, v
+
+        n = 1
+        v = 0.1105189233267572e-3_wp
+        call gen_oh(1, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        v = 0.9205232738090741e-3_wp
+        call gen_oh(2, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        v = 0.9133159786443561e-3_wp
+        call gen_oh(3, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.3712636449657089e-1_wp
+        v = 0.3690421898017899e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9140060412262223e-1_wp
+        v = 0.5603990928680660e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.1531077852469906e+0_wp
+        v = 0.6865297629282609e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2180928891660612e+0_wp
+        v = 0.7720338551145630e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2839874532200175e+0_wp
+        v = 0.8301545958894795e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.3491177600963764e+0_wp
+        v = 0.8686692550179628e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4121431461444309e+0_wp
+        v = 0.8927076285846890e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4718993627149127e+0_wp
+        v = 0.9060820238568219e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.5273145452842337e+0_wp
+        v = 0.9119777254940867e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6209475332444019e+0_wp
+        v = 0.9128720138604181e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6569722711857291e+0_wp
+        v = 0.9130714935691735e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.6841788309070143e+0_wp
+        v = 0.9152873784554116e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7012604330123631e+0_wp
+        v = 0.9187436274321654e-3_wp
+        call gen_oh(4, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.1072382215478166e+0_wp
+        v = 0.5176977312965694e-3_wp
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.2582068959496968e+0_wp
+        v = 0.7331143682101417e-3_wp
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.4172752955306717e+0_wp
+        v = 0.8463232836379928e-3_wp
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.5700366911792503e+0_wp
+        v = 0.9031122694253992e-3_wp
+        call gen_oh(5, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9827986018263947e+0_wp
+        b = 0.1771774022615325e+0_wp
+        v = 0.6485778453163257e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9624249230326228e+0_wp
+        b = 0.2475716463426288e+0_wp
+        v = 0.7435030910982369e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9402007994128811e+0_wp
+        b = 0.3354616289066489e+0_wp
+        v = 0.7998527891839054e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9320822040143202e+0_wp
+        b = 0.3173615246611977e+0_wp
+        v = 0.8101731497468018e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.9043674199393299e+0_wp
+        b = 0.4090268427085357e+0_wp
+        v = 0.8483389574594331e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8912407560074747e+0_wp
+        b = 0.3854291150669224e+0_wp
+        v = 0.8556299257311812e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8676435628462708e+0_wp
+        b = 0.4932221184851285e+0_wp
+        v = 0.8803208679738260e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8581979986041619e+0_wp
+        b = 0.4785320675922435e+0_wp
+        v = 0.8811048182425720e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8396753624049856e+0_wp
+        b = 0.4507422593157064e+0_wp
+        v = 0.8850282341265444e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8165288564022188e+0_wp
+        b = 0.5632123020762100e+0_wp
+        v = 0.9021342299040653e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.8015469370783529e+0_wp
+        b = 0.5434303569693900e+0_wp
+        v = 0.9010091677105086e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7773563069070351e+0_wp
+        b = 0.5123518486419871e+0_wp
+        v = 0.9022692938426915e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7661621213900394e+0_wp
+        b = 0.6394279634749102e+0_wp
+        v = 0.9158016174693465e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7553584143533510e+0_wp
+        b = 0.6269805509024392e+0_wp
+        v = 0.9131578003189435e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7344305757559503e+0_wp
+        b = 0.6031161693096310e+0_wp
+        v = 0.9107813579482705e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        a = 0.7043837184021765e+0_wp
+        b = 0.5693702498468441e+0_wp
+        v = 0.9105760258970126e-3_wp
+        call gen_oh(6, n, x(n:), y(n:), z(n:), w(n:), a, b, v)
+        n = n - 1
+    end subroutine LD1202
+
+end module grid

--- a/scf/src/xc.f90
+++ b/scf/src/xc.f90
@@ -1,0 +1,277 @@
+module xc
+    implicit none
+
+    private
+    public :: vwn5_correlation, pw92_correlation, pbe_exchange, pbe_correlation
+
+    integer, parameter :: wp = selected_real_kind(15)
+    real(wp), parameter :: pi = 4.0_wp*atan(1.0_wp)
+
+    !> density threshold below which all outputs are set to zero
+    real(wp), parameter :: rho_thr = 1.0e-15_wp
+
+    !> VWN-5 parameters
+    !! S.H. Vosko, L. Wilk, M. Nusair, Can. J. Phys. 58, 1200 (1980)
+    real(wp), parameter :: vwn_A  =  0.0621814_wp
+    real(wp), parameter :: vwn_b  =  3.72744_wp
+    real(wp), parameter :: vwn_c  = 12.9352_wp
+    real(wp), parameter :: vwn_x0 = -0.10498_wp
+
+    !> PW92 parameters (unpolarized electron gas)
+    !! J.P. Perdew, Y. Wang, Phys. Rev. B 45, 13244 (1992)
+    real(wp), parameter :: pw92_A  = 0.0310907_wp
+    real(wp), parameter :: pw92_a1 = 0.21370_wp
+    real(wp), parameter :: pw92_b1 = 7.5957_wp
+    real(wp), parameter :: pw92_b2 = 3.5876_wp
+    real(wp), parameter :: pw92_b3 = 1.6382_wp
+    real(wp), parameter :: pw92_b4 = 0.49294_wp
+
+    !> PBE exchange parameters
+    !! J.P. Perdew, K. Burke, M. Ernzerhof, PRL 77, 3865 (1996)
+    real(wp), parameter :: pbe_kappa = 0.8040_wp
+    real(wp), parameter :: pbe_mu    = 0.2195149727645171_wp
+
+    !> PBE correlation parameters
+    real(wp), parameter :: pbe_gamma = 0.03109069086965489503494086371273_wp
+    real(wp), parameter :: pbe_beta  = 0.06672455060314922_wp
+
+contains
+
+!> VWN-5 correlation energy density and potential (spin-unpolarized)
+!!
+!! Returns the correlation energy density per particle eps_c and the
+!! correlation potential v_c = d(rho*eps_c)/drho for a given density rho.
+    subroutine vwn5_correlation(rho, eps_c, v_c)
+        real(wp), intent(in)  :: rho
+        real(wp), intent(out) :: eps_c, v_c
+
+        real(wp) :: rs, x, Xx, Xx0, Q, decdx
+
+        if (rho < rho_thr) then
+            eps_c = 0.0_wp
+            v_c   = 0.0_wp
+            return
+        end if
+
+        ! Wigner-Seitz radius
+        rs = (3.0_wp/(4.0_wp*pi*rho))**(1.0_wp/3.0_wp)
+        x  = sqrt(rs)
+
+        ! X(x) = x^2 + b*x + c
+        Xx  = x*x + vwn_b*x + vwn_c
+        Xx0 = vwn_x0*vwn_x0 + vwn_b*vwn_x0 + vwn_c
+        Q   = sqrt(4.0_wp*vwn_c - vwn_b*vwn_b)
+
+        ! energy density
+        eps_c = 0.5_wp*vwn_A*( &
+            log(x*x/Xx) &
+            + (2.0_wp*vwn_b/Q)*atan(Q/(2.0_wp*x + vwn_b)) &
+            - (vwn_b*vwn_x0/Xx0)*( &
+                log((x - vwn_x0)**2/Xx) &
+                + (2.0_wp*(vwn_b + 2.0_wp*vwn_x0)/Q) &
+                    *atan(Q/(2.0_wp*x + vwn_b)) &
+            ) &
+        )
+
+        ! derivative d(eps_c)/dx
+        decdx = 0.5_wp*vwn_A*( &
+            2.0_wp/x - (2.0_wp*x + 2.0_wp*vwn_b)/Xx &
+            - (vwn_b*vwn_x0/Xx0)*( &
+                2.0_wp/(x - vwn_x0) &
+                - 2.0_wp*(x + vwn_b + vwn_x0)/Xx &
+            ) &
+        )
+
+        ! potential: v_c = eps_c - (x/6) * d(eps_c)/dx
+        v_c = eps_c - (x/6.0_wp)*decdx
+
+    end subroutine vwn5_correlation
+
+
+!> PW92 correlation energy density and potential (spin-unpolarized)
+!!
+!! J.P. Perdew, Y. Wang, Phys. Rev. B 45, 13244 (1992)
+!! This is the LDA correlation used internally by PBE correlation.
+    subroutine pw92_correlation(rho, eps_c, v_c)
+        real(wp), intent(in)  :: rho
+        real(wp), intent(out) :: eps_c, v_c
+
+        real(wp) :: rs, srs, Q, dQdrs, G, dGdrs, F, dFdrs
+
+        if (rho < rho_thr) then
+            eps_c = 0.0_wp
+            v_c   = 0.0_wp
+            return
+        end if
+
+        rs  = (3.0_wp/(4.0_wp*pi*rho))**(1.0_wp/3.0_wp)
+        srs = sqrt(rs)
+
+        ! Q(rs) = 2A(b1*rs^(1/2) + b2*rs + b3*rs^(3/2) + b4*rs^2)
+        Q = 2.0_wp*pw92_A*(pw92_b1*srs + pw92_b2*rs &
+            + pw92_b3*srs*rs + pw92_b4*rs*rs)
+
+        ! dQ/drs
+        dQdrs = 2.0_wp*pw92_A*(pw92_b1/(2.0_wp*srs) + pw92_b2 &
+            + 1.5_wp*pw92_b3*srs + 2.0_wp*pw92_b4*rs)
+
+        ! G(rs) = -2A(1 + a1*rs)  [prefactor]
+        G = -2.0_wp*pw92_A*(1.0_wp + pw92_a1*rs)
+        dGdrs = -2.0_wp*pw92_A*pw92_a1
+
+        ! F(rs) = ln(1 + 1/Q)  [log term]
+        F = log(1.0_wp + 1.0_wp/Q)
+        dFdrs = -dQdrs/(Q*(Q + 1.0_wp))
+
+        ! eps_c = G * F
+        eps_c = G*F
+
+        ! v_c = eps_c - (rs/3) * d(eps_c)/d(rs)
+        v_c = eps_c - (rs/3.0_wp)*(dGdrs*F + G*dFdrs)
+
+    end subroutine pw92_correlation
+
+
+!> PBE exchange energy density, potential and sigma-derivative
+!!
+!! Returns the PBE exchange energy density per particle eps_x,
+!! vrho = d(rho*eps_x)/drho, and vsigma = d(rho*eps_x)/dsigma
+!! where sigma = |nabla rho|^2.
+    subroutine pbe_exchange(rho, sigma, eps_x, vrho, vsigma)
+        real(wp), intent(in)  :: rho, sigma
+        real(wp), intent(out) :: eps_x, vrho, vsigma
+
+        real(wp) :: ex_lda, kf2, s2, denom, Fx, dFds2
+
+        if (rho < rho_thr) then
+            eps_x  = 0.0_wp
+            vrho   = 0.0_wp
+            vsigma = 0.0_wp
+            return
+        end if
+
+        ! LDA exchange energy density per particle
+        ! eps_x^LDA = -(3/4)(3/pi)^(1/3) rho^(1/3)
+        ex_lda = -0.75_wp*(3.0_wp/pi)**(1.0_wp/3.0_wp)*rho**(1.0_wp/3.0_wp)
+
+        ! s^2 = sigma / (4 * (3*pi^2)^(2/3) * rho^(8/3))
+        kf2 = (3.0_wp*pi*pi)**(2.0_wp/3.0_wp)
+        s2  = sigma/(4.0_wp*kf2*rho**(8.0_wp/3.0_wp))
+
+        ! enhancement factor F_x = 1 + kappa - kappa/(1 + mu*s^2/kappa)
+        denom = 1.0_wp + pbe_mu*s2/pbe_kappa
+        Fx    = 1.0_wp + pbe_kappa - pbe_kappa/denom
+
+        ! dF_x/d(s^2) = mu / (1 + mu*s^2/kappa)^2
+        dFds2 = pbe_mu/denom**2
+
+        ! energy density
+        eps_x = ex_lda*Fx
+
+        ! potential: d(rho*eps_x)/drho
+        ! = (4/3)*ex_lda*Fx - (8/3)*ex_lda*s2*dFds2
+        vrho = (4.0_wp/3.0_wp)*ex_lda*Fx &
+             - (8.0_wp/3.0_wp)*ex_lda*s2*dFds2
+
+        ! sigma-derivative: d(rho*eps_x)/dsigma
+        ! = rho*ex_lda*dFds2 / (4*kf2*rho^(8/3))
+        vsigma = ex_lda*dFds2/(4.0_wp*kf2*rho**(5.0_wp/3.0_wp))
+
+    end subroutine pbe_exchange
+
+
+!> PBE correlation energy density, potential and sigma-derivative
+!!
+!! Uses PW92 as the LDA correlation base, consistent with the original
+!! PBE paper (Perdew, Burke, Ernzerhof, PRL 77, 3865, 1996).
+!!
+!! Returns the PBE correlation energy density per particle eps_c,
+!! vrho = d(rho*eps_c)/drho, and vsigma = d(rho*eps_c)/dsigma
+!! where sigma = |nabla rho|^2.
+    subroutine pbe_correlation(rho, sigma, eps_c, vrho, vsigma)
+        real(wp), intent(in)  :: rho, sigma
+        real(wp), intent(out) :: eps_c, vrho, vsigma
+
+        real(wp) :: e0, v0, de0drho
+        real(wp) :: ks2, t2
+        real(wp) :: argexp, expval, A, dAdrho
+        real(wp) :: At2, A2t4, fAtden, fAtden2
+        real(wp) :: P, dPdt2, dPdA
+        real(wp) :: dt2drho, dt2dsigma
+        real(wp) :: arglog, H, dHdrho, dHdsigma
+
+        if (rho < rho_thr) then
+            eps_c  = 0.0_wp
+            vrho   = 0.0_wp
+            vsigma = 0.0_wp
+            return
+        end if
+
+        ! LDA correlation (PW92)
+        call pw92_correlation(rho, e0, v0)
+
+        ! Thomas-Fermi screening: ks^2 = 4*(3*pi^2)^(1/3)*rho^(1/3)/pi
+        ks2 = 4.0_wp*(3.0_wp*pi*pi)**(1.0_wp/3.0_wp)*rho**(1.0_wp/3.0_wp)/pi
+
+        ! reduced density gradient squared: t^2 = sigma/(4*ks^2*rho^2)
+        t2 = sigma/(4.0_wp*ks2*rho*rho)
+
+        ! A = (beta/gamma) / [exp(-e0/gamma) - 1]
+        argexp = -e0/pbe_gamma
+        if (abs(argexp) < 40.0_wp) then
+            expval = exp(argexp)
+        else
+            expval = 0.0_wp
+        end if
+        A = (pbe_beta/pbe_gamma)/(expval - 1.0_wp)
+
+        ! convenience
+        At2    = A*t2
+        A2t4   = At2*At2
+        fAtden = 1.0_wp + At2 + A2t4
+        fAtden2 = fAtden*fAtden
+
+        ! P = (beta/gamma)*t^2*(1+A*t^2)/(1+A*t^2+A^2*t^4)
+        P = (pbe_beta/pbe_gamma)*t2*(1.0_wp + At2)/fAtden
+
+        ! arglog = 1 + P
+        arglog = 1.0_wp + P
+
+        ! H = gamma * ln(arglog)   [phi=1 for spin-restricted]
+        H = pbe_gamma*log(arglog)
+
+        ! energy density
+        eps_c = e0 + H
+
+        ! --- derivatives for the potential ---
+
+        ! dP/dt^2 = (beta/gamma) * (1 + 2*A*t^2) / (1+At^2+A^2t^4)^2
+        dPdt2 = (pbe_beta/pbe_gamma)*(1.0_wp + 2.0_wp*At2)/fAtden2
+
+        ! dP/dA = -(beta/gamma) * A * t^6 * (2+At^2) / (1+At^2+A^2t^4)^2
+        dPdA = -(pbe_beta/pbe_gamma)*A*t2*t2*t2*(2.0_wp + At2)/fAtden2
+
+        ! dt^2/drho = -(7/3)*t^2/rho
+        dt2drho = -(7.0_wp/3.0_wp)*t2/rho
+
+        ! dt^2/dsigma = 1/(4*ks^2*rho^2)
+        dt2dsigma = 1.0_wp/(4.0_wp*ks2*rho*rho)
+
+        ! dA/drho = A*exp(-e0/gamma)/((exp(-e0/gamma)-1)*gamma) * de0/drho
+        ! where de0/drho = (v0 - e0)/rho
+        de0drho = (v0 - e0)/rho
+        dAdrho  = A*expval/((expval - 1.0_wp)*pbe_gamma)*de0drho
+
+        ! dH/drho and dH/dsigma
+        dHdrho   = pbe_gamma/arglog*(dPdt2*dt2drho + dPdA*dAdrho)
+        dHdsigma = pbe_gamma/arglog*dPdt2*dt2dsigma
+
+        ! vrho = d(rho*eps_c)/drho = v0 + H + rho*dH/drho
+        vrho = v0 + H + rho*dHdrho
+
+        ! vsigma = d(rho*eps_c)/dsigma = rho*dH/dsigma
+        vsigma = rho*dHdsigma
+
+    end subroutine pbe_correlation
+
+end module xc

--- a/scf/test/test_grid.f90
+++ b/scf/test/test_grid.f90
@@ -1,0 +1,204 @@
+program test_grid
+    use grid, only: generate_grid
+    implicit none
+
+    integer, parameter :: wp = selected_real_kind(15)
+    real(wp), parameter :: pi = 4.0_wp*atan(1.0_wp)
+
+    logical :: all_passed
+
+    all_passed = .true.
+    call test_grid_size(all_passed)
+    call test_grid_size_override(all_passed)
+    call test_positive_weights(all_passed)
+    call test_gaussian_single_atom(all_passed)
+    call test_gaussian_two_atoms(all_passed)
+    call test_gaussian_h2_nang230(all_passed)
+    call test_gaussian_h2_nang434(all_passed)
+    call test_gaussian_h2_nang1202(all_passed)
+    call test_gaussian_h2_huge(all_passed)
+
+    if (.not. all_passed) then
+        write (*, '(a)') 'SOME TESTS FAILED'
+        error stop 1
+    end if
+    write (*, '(a)') 'ALL TESTS PASSED'
+
+contains
+
+!> check that ngrid matches expected nr*nl per atom
+    subroutine test_grid_size(passed)
+        logical, intent(inout) :: passed
+        ! H2: two hydrogen atoms -> 2 * 35 * 230 = 16100
+        real(wp) :: xyz(3, 2), chrg(2)
+        real(wp), allocatable :: grid_xyz(:, :), grid_w(:)
+        integer :: ngrid
+
+        xyz(:, 1) = [0.0_wp, 0.0_wp, -0.7_wp]
+        xyz(:, 2) = [0.0_wp, 0.0_wp, 0.7_wp]
+        chrg = [1.0_wp, 1.0_wp]
+
+        call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid)
+
+        if (ngrid /= 2*35*230) then
+            write (*, '(a,i0,a,i0)') 'FAIL test_grid_size: got ', ngrid, &
+                ', expected ', 2*35*230
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_grid_size'
+        end if
+    end subroutine test_grid_size
+
+!> check that nrad/nang optional arguments override grid size
+    subroutine test_grid_size_override(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: xyz(3, 1), chrg(1)
+        real(wp), allocatable :: grid_xyz(:, :), grid_w(:)
+        integer :: ngrid
+
+        xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+        chrg = [6.0_wp]  ! carbon: default would be 65*434
+
+        call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid, nrad=20, nang=230)
+
+        if (ngrid /= 20*230) then
+            write (*, '(a,i0,a,i0)') 'FAIL test_grid_size_override: got ', ngrid, &
+                ', expected ', 20*230
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_grid_size_override'
+        end if
+    end subroutine test_grid_size_override
+
+!> all integration weights must be non-negative when using the 434-point
+!! Lebedev rule (the 230-point rule has known negative axial weights)
+    subroutine test_positive_weights(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: xyz(3, 2), chrg(2)
+        real(wp), allocatable :: grid_xyz(:, :), grid_w(:)
+        integer :: ngrid, nneg
+
+        ! use carbon atoms so we get the 434-point Lebedev rule
+        xyz(:, 1) = [0.0_wp, 0.0_wp, -1.2_wp]
+        xyz(:, 2) = [0.0_wp, 0.0_wp, 1.2_wp]
+        chrg = [6.0_wp, 6.0_wp]
+
+        call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid)
+
+        nneg = count(grid_w < 0.0_wp)
+        if (nneg > 0) then
+            write (*, '(a,i0,a)') 'FAIL test_positive_weights: ', nneg, &
+                ' negative weights'
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_positive_weights'
+        end if
+    end subroutine test_positive_weights
+
+!> integrate exp(-r^2) over all space for a single atom at the origin
+!! analytical result: pi^(3/2) = 5.568328...
+    subroutine test_gaussian_single_atom(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: xyz(3, 1), chrg(1)
+        real(wp), allocatable :: grid_xyz(:, :), grid_w(:)
+        integer :: ngrid, ig
+        real(wp) :: r2, integral, exact, rel_err
+
+        xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+        chrg = [1.0_wp]
+
+        call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid)
+
+        integral = 0.0_wp
+        do ig = 1, ngrid
+            r2 = grid_xyz(1, ig)**2 + grid_xyz(2, ig)**2 + grid_xyz(3, ig)**2
+            integral = integral + grid_w(ig)*exp(-r2)
+        end do
+
+        exact = pi**(1.5_wp)
+        rel_err = abs(integral - exact)/exact
+
+        if (rel_err > 1.0e-4_wp) then
+            write (*, '(a,es12.5,a,es12.5,a,es8.1)') &
+                'FAIL test_gaussian_single_atom: got ', integral, &
+                ', expected ', exact, ', rel_err=', rel_err
+            passed = .false.
+        else
+            write (*, '(a,es8.1)') 'PASS test_gaussian_single_atom  rel_err=', rel_err
+        end if
+    end subroutine test_gaussian_single_atom
+
+!> integrate exp(-r^2) for H2 molecule (default grid)
+!! Becke partition of unity means this must still give pi^(3/2)
+    subroutine test_gaussian_two_atoms(passed)
+        logical, intent(inout) :: passed
+        call gaussian_h2_helper(passed, 'test_gaussian_two_atoms   ')
+    end subroutine test_gaussian_two_atoms
+
+!> H2 Gaussian integral with nang=230
+    subroutine test_gaussian_h2_nang230(passed)
+        logical, intent(inout) :: passed
+        call gaussian_h2_helper(passed, 'test_gaussian_h2_nang230  ', nang=230)
+    end subroutine test_gaussian_h2_nang230
+
+!> H2 Gaussian integral with nang=434
+    subroutine test_gaussian_h2_nang434(passed)
+        logical, intent(inout) :: passed
+        call gaussian_h2_helper(passed, 'test_gaussian_h2_nang434  ', nang=434)
+    end subroutine test_gaussian_h2_nang434
+
+!> H2 Gaussian integral with nang=1202
+    subroutine test_gaussian_h2_nang1202(passed)
+        logical, intent(inout) :: passed
+        call gaussian_h2_helper(passed, 'test_gaussian_h2_nang1202 ', nang=1202)
+    end subroutine test_gaussian_h2_nang1202
+
+!> H2 Gaussian integral with huge grid: nrad=200, nang=1202
+!! with a tighter tolerance to check convergence
+    subroutine test_gaussian_h2_huge(passed)
+        logical, intent(inout) :: passed
+        call gaussian_h2_helper(passed, 'test_gaussian_h2_huge     ', &
+            nrad=250, nang=434, tol=1.0e-10_wp)
+    end subroutine test_gaussian_h2_huge
+
+!> helper: integrate exp(-r^2) over H2 with optional grid size overrides
+    subroutine gaussian_h2_helper(passed, label, nrad, nang, tol)
+        logical, intent(inout) :: passed
+        character(len=*), intent(in) :: label
+        integer, optional, intent(in) :: nrad, nang
+        real(wp), optional, intent(in) :: tol
+
+        real(wp) :: xyz(3, 2), chrg(2)
+        real(wp), allocatable :: grid_xyz(:, :), grid_w(:)
+        integer :: ngrid, ig
+        real(wp) :: r2, integral, exact, rel_err, threshold
+
+        xyz(:, 1) = [0.0_wp, 0.0_wp, -0.7_wp]
+        xyz(:, 2) = [0.0_wp, 0.0_wp, 0.7_wp]
+        chrg = [1.0_wp, 1.0_wp]
+
+        call generate_grid(xyz, chrg, grid_xyz, grid_w, ngrid, nrad=nrad, nang=nang)
+
+        integral = 0.0_wp
+        do ig = 1, ngrid
+            r2 = grid_xyz(1, ig)**2 + grid_xyz(2, ig)**2 + grid_xyz(3, ig)**2
+            integral = integral + grid_w(ig)*exp(-r2)
+        end do
+
+        exact = pi**(1.5_wp)
+        rel_err = abs(integral - exact)/exact
+
+        threshold = 1.0e-4_wp
+        if (present(tol)) threshold = tol
+
+        if (rel_err > threshold) then
+            write (*, '(a,a,a,es12.5,a,es12.5,a,es8.1)') &
+                'FAIL ', label, ': got ', integral, &
+                ', expected ', exact, ', rel_err=', rel_err
+            passed = .false.
+        else
+            write (*, '(a,a,a,es8.1)') 'PASS ', label, ' rel_err=', rel_err
+        end if
+    end subroutine gaussian_h2_helper
+
+end program test_grid

--- a/scf/test/test_xc.f90
+++ b/scf/test/test_xc.f90
@@ -1,0 +1,426 @@
+program test_xc
+    use xc, only: vwn5_correlation, pbe_exchange, pbe_correlation
+    implicit none
+
+    integer, parameter :: wp = selected_real_kind(15)
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    ! --- VWN-5 correlation ---
+    call test_vwn5_zero_density(all_passed)
+    call test_vwn5_potential_numerical(all_passed)
+    call test_vwn5_libxc(all_passed)
+
+    ! --- PBE exchange ---
+    call test_pbe_x_zero_density(all_passed)
+    call test_pbe_x_lda_limit(all_passed)
+    call test_pbe_x_potential_numerical(all_passed)
+    call test_pbe_x_libxc(all_passed)
+
+    ! --- PBE correlation ---
+    call test_pbe_c_zero_density(all_passed)
+    call test_pbe_c_lda_limit(all_passed)
+    call test_pbe_c_potential_numerical(all_passed)
+    call test_pbe_c_libxc(all_passed)
+
+    if (.not. all_passed) then
+        write (*, '(a)') 'SOME TESTS FAILED'
+        error stop 1
+    end if
+    write (*, '(a)') 'ALL TESTS PASSED'
+
+contains
+
+! ================================================================
+!  Helpers
+! ================================================================
+
+!> compare against a libxc reference value for VWN-5
+!! libxc convention: zk = rho*eps_c (energy per volume), vrhoa = d(zk)/d(rhoa)
+!! for unpolarized: rho = 2*rhoa, eps = zk/rho, vrho = vrhoa
+    subroutine check_vwn_ref(passed, label, rhoa, zk_ref, vrhoa_ref, tol)
+        logical, intent(inout) :: passed
+        character(len=*), intent(in) :: label
+        real(wp), intent(in) :: rhoa, zk_ref, vrhoa_ref, tol
+
+        real(wp) :: rho, eps_c, v_c
+        real(wp) :: eps_ref, err_e, err_v
+
+        rho = 2.0_wp*rhoa
+        call vwn5_correlation(rho, eps_c, v_c)
+
+        eps_ref = zk_ref/rho
+        err_e = abs(eps_c - eps_ref)/abs(eps_ref)
+        err_v = abs(v_c - vrhoa_ref)/abs(vrhoa_ref)
+
+        if (err_e > tol .or. err_v > tol) then
+            write (*, '(a,a,a,es10.3,a,es10.3)') 'FAIL ', label, &
+                '  rel_e=', err_e, '  rel_v=', err_v
+            passed = .false.
+        else
+            write (*, '(a,a)') 'PASS ', label
+        end if
+    end subroutine check_vwn_ref
+
+!> compare against a libxc reference value for a GGA functional
+!! for unpolarized: rho = 2*rhoa, sigma = 4*sigmaaa
+!! vsigma = (vsigmaaa + vsigmaab + vsigmabb) / 4
+    subroutine check_gga_ref(passed, label, func, rhoa, sigmaaa, &
+            zk_ref, vrhoa_ref, vsigmaaa_ref, vsigmaab_ref, vsigmabb_ref, tol)
+        logical, intent(inout) :: passed
+        character(len=*), intent(in) :: label
+        character(len=1), intent(in) :: func  ! 'x' or 'c'
+        real(wp), intent(in) :: rhoa, sigmaaa
+        real(wp), intent(in) :: zk_ref, vrhoa_ref
+        real(wp), intent(in) :: vsigmaaa_ref, vsigmaab_ref, vsigmabb_ref
+        real(wp), intent(in) :: tol
+
+        real(wp) :: rho, sigma, eps, vrho, vsigma
+        real(wp) :: eps_ref, vsigma_ref
+        real(wp) :: err_e, err_v, err_s
+
+        rho   = 2.0_wp*rhoa
+        sigma = 4.0_wp*sigmaaa
+
+        if (func == 'x') then
+            call pbe_exchange(rho, sigma, eps, vrho, vsigma)
+        else
+            call pbe_correlation(rho, sigma, eps, vrho, vsigma)
+        end if
+
+        eps_ref    = zk_ref/rho
+        vsigma_ref = (vsigmaaa_ref + vsigmaab_ref + vsigmabb_ref)/4.0_wp
+
+        err_e = abs(eps - eps_ref)/abs(eps_ref)
+        err_v = abs(vrho - vrhoa_ref)/abs(vrhoa_ref)
+        err_s = abs(vsigma - vsigma_ref)/abs(vsigma_ref)
+
+        if (err_e > tol .or. err_v > tol .or. err_s > tol) then
+            write (*, '(a,a,a,3es10.3)') 'FAIL ', label, &
+                '  rel(e,v,s)=', err_e, err_v, err_s
+            passed = .false.
+        else
+            write (*, '(a,a)') 'PASS ', label
+        end if
+    end subroutine check_gga_ref
+
+! ================================================================
+!  VWN-5 tests
+! ================================================================
+
+!> VWN-5 should return zeros for zero density
+    subroutine test_vwn5_zero_density(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: eps_c, v_c
+
+        call vwn5_correlation(0.0_wp, eps_c, v_c)
+
+        if (eps_c /= 0.0_wp .or. v_c /= 0.0_wp) then
+            write (*, '(a)') 'FAIL test_vwn5_zero_density'
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_vwn5_zero_density'
+        end if
+    end subroutine test_vwn5_zero_density
+
+!> verify VWN-5 potential by numerical differentiation of rho*eps_c
+    subroutine test_vwn5_potential_numerical(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: rho, h, eps_p, v_p, eps_m, v_m, eps_c, v_c
+        real(wp) :: v_num, rel_err
+
+        rho = 0.1_wp
+        h   = 1.0e-6_wp
+
+        call vwn5_correlation(rho + h, eps_p, v_p)
+        call vwn5_correlation(rho - h, eps_m, v_m)
+        call vwn5_correlation(rho, eps_c, v_c)
+
+        v_num = ((rho + h)*eps_p - (rho - h)*eps_m)/(2.0_wp*h)
+        rel_err = abs(v_c - v_num)/abs(v_c)
+
+        if (rel_err > 1.0e-6_wp) then
+            write (*, '(a,es12.5,a,es12.5,a,es8.1)') &
+                'FAIL test_vwn5_potential_numerical: v_c=', v_c, &
+                ' v_num=', v_num, ' rel_err=', rel_err
+            passed = .false.
+        else
+            write (*, '(a,es8.1)') 'PASS test_vwn5_potential_numerical  rel_err=', rel_err
+        end if
+    end subroutine test_vwn5_potential_numerical
+
+!> compare VWN-5 against libxc reference data (test/refs/lda_c_vwn.data)
+    subroutine test_vwn5_libxc(passed)
+        logical, intent(inout) :: passed
+        real(wp), parameter :: tol = 1.0e-11_wp
+
+        ! rhoa=1.7, rhob=1.7, sigma~0
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=3.40 ', &
+            1.7_wp, -0.278978177367_wp, -0.0907896301530_wp, tol)
+
+        ! rhoa=1.5, rhob=1.5
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=3.00 ', &
+            1.5_wp, -0.242883397986_wp, -0.0896613951966_wp, tol)
+
+        ! rhoa=0.088, rhob=0.088
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=0.176', &
+            0.088_wp, -0.0101483720780_wp, -0.0653289336535_wp, tol)
+
+        ! rhoa=0.26, rhob=0.26
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=0.52 ', &
+            0.26_wp, -0.0344300981310_wp, -0.0743196778205_wp, tol)
+
+        ! rhoa=0.15, rhob=0.15
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=0.30 ', &
+            0.15_wp, -0.0185432270230_wp, -0.0697024933328_wp, tol)
+
+        ! rhoa=1800, rhob=1800 (high density)
+        call check_vwn_ref(passed, 'vwn5_libxc  rho=3600 ', &
+            1800.0_wp, -0.532741477023e+03_wp, -0.157944671704_wp, tol)
+    end subroutine test_vwn5_libxc
+
+! ================================================================
+!  PBE exchange tests
+! ================================================================
+
+!> PBE exchange should return zeros for zero density
+    subroutine test_pbe_x_zero_density(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: eps_x, vrho, vsigma
+
+        call pbe_exchange(0.0_wp, 0.0_wp, eps_x, vrho, vsigma)
+
+        if (eps_x /= 0.0_wp .or. vrho /= 0.0_wp .or. vsigma /= 0.0_wp) then
+            write (*, '(a)') 'FAIL test_pbe_x_zero_density'
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_pbe_x_zero_density'
+        end if
+    end subroutine test_pbe_x_zero_density
+
+!> PBE exchange with sigma=0 should reduce to LDA exchange
+    subroutine test_pbe_x_lda_limit(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: rho, eps_x, vrho, vsigma
+        real(wp), parameter :: pi_val = 4.0_wp*atan(1.0_wp)
+        real(wp) :: ex_lda, vx_lda, rel_err_e, rel_err_v
+
+        rho = 0.1_wp
+        call pbe_exchange(rho, 0.0_wp, eps_x, vrho, vsigma)
+
+        ex_lda = -0.75_wp*(3.0_wp/pi_val)**(1.0_wp/3.0_wp)*rho**(1.0_wp/3.0_wp)
+        vx_lda = (4.0_wp/3.0_wp)*ex_lda
+
+        rel_err_e = abs(eps_x - ex_lda)/abs(ex_lda)
+        rel_err_v = abs(vrho - vx_lda)/abs(vx_lda)
+
+        if (rel_err_e > 1.0e-12_wp .or. rel_err_v > 1.0e-12_wp) then
+            write (*, '(a,2es12.5)') 'FAIL test_pbe_x_lda_limit  err=', &
+                rel_err_e, rel_err_v
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_pbe_x_lda_limit'
+        end if
+    end subroutine test_pbe_x_lda_limit
+
+!> verify PBE exchange potential and vsigma by numerical differentiation
+    subroutine test_pbe_x_potential_numerical(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: rho, sigma, h
+        real(wp) :: eps_x, vrho, vsigma
+        real(wp) :: eps_p, vr_p, vs_p, eps_m, vr_m, vs_m
+        real(wp) :: vrho_num, vsigma_num, rel_err_rho, rel_err_sigma
+
+        rho   = 0.1_wp
+        sigma = 0.01_wp
+        h     = 1.0e-6_wp
+
+        call pbe_exchange(rho, sigma, eps_x, vrho, vsigma)
+
+        call pbe_exchange(rho + h, sigma, eps_p, vr_p, vs_p)
+        call pbe_exchange(rho - h, sigma, eps_m, vr_m, vs_m)
+        vrho_num = ((rho + h)*eps_p - (rho - h)*eps_m)/(2.0_wp*h)
+        rel_err_rho = abs(vrho - vrho_num)/abs(vrho)
+
+        call pbe_exchange(rho, sigma + h, eps_p, vr_p, vs_p)
+        call pbe_exchange(rho, sigma - h, eps_m, vr_m, vs_m)
+        vsigma_num = (rho*eps_p - rho*eps_m)/(2.0_wp*h)
+        rel_err_sigma = abs(vsigma - vsigma_num)/abs(vsigma)
+
+        if (rel_err_rho > 1.0e-5_wp .or. rel_err_sigma > 1.0e-5_wp) then
+            write (*, '(a,2es12.5)') &
+                'FAIL test_pbe_x_potential_numerical  err=', &
+                rel_err_rho, rel_err_sigma
+            passed = .false.
+        else
+            write (*, '(a,2es8.1)') &
+                'PASS test_pbe_x_potential_numerical  rel_err=', &
+                rel_err_rho, rel_err_sigma
+        end if
+    end subroutine test_pbe_x_potential_numerical
+
+!> compare PBE exchange against libxc reference data (test/refs/gga_x_pbe.data)
+    subroutine test_pbe_x_libxc(passed)
+        logical, intent(inout) :: passed
+        real(wp), parameter :: tol = 1.0e-11_wp
+
+        ! rhoa=1.7, sigma~0 (LDA limit)
+        call check_gga_ref(passed, 'pbe_x_libxc rho=3.40  sig~0  ', 'x', &
+            1.7_wp, 0.81e-11_wp, &
+            -0.377592720836e+01_wp, -0.148075576798e+01_wp, &
+            -0.165665974842e-02_wp, 0.0_wp, -0.165665974842e-02_wp, tol)
+
+        ! rhoa=1.7, sigmaaa=1.7 (moderate gradient)
+        call check_gga_ref(passed, 'pbe_x_libxc rho=3.40  sig=6.8', 'x', &
+            1.7_wp, 1.7_wp, &
+            -0.378154942017e+01_wp, -0.147855914532e+01_wp, &
+            -0.165052935245e-02_wp, 0.0_wp, -0.165052935245e-02_wp, tol)
+
+        ! rhoa=1.5, sigmaaa=36 (large gradient)
+        call check_gga_ref(passed, 'pbe_x_libxc rho=3.00  sig=144', 'x', &
+            1.5_wp, 36.0_wp, &
+            -0.332917118617e+01_wp, -0.136704102604e+01_wp, &
+            -0.175922831660e-02_wp, 0.0_wp, -0.175922831660e-02_wp, tol)
+
+        ! rhoa=0.088, sigmaaa=0.087 (low density)
+        call check_gga_ref(passed, 'pbe_x_libxc rho=0.176 sig=0.3', 'x', &
+            0.088_wp, 0.087_wp, &
+            -0.847500738867e-01_wp, -0.498335317577e+00_wp, &
+            -0.545109539268e-01_wp, 0.0_wp, -0.545109539268e-01_wp, tol)
+
+        ! rhoa=0.26, sigmaaa=0.28
+        call check_gga_ref(passed, 'pbe_x_libxc rho=0.52  sig=1.1', 'x', &
+            0.26_wp, 0.28_wp, &
+            -0.319679717401e+00_wp, -0.766494428708e+00_wp, &
+            -0.185240091115e-01_wp, 0.0_wp, -0.185240091115e-01_wp, tol)
+
+        ! rhoa=1800, sigmaaa=0.55 (high density, low gradient)
+        call check_gga_ref(passed, 'pbe_x_libxc rho=3600  sig=2.2', 'x', &
+            1800.0_wp, 0.55_wp, &
+            -0.407494475322e+05_wp, -0.150923879748e+02_wp, &
+            -0.153509482897e-06_wp, 0.0_wp, -0.153509482897e-06_wp, tol)
+    end subroutine test_pbe_x_libxc
+
+! ================================================================
+!  PBE correlation tests
+! ================================================================
+
+!> PBE correlation should return zeros for zero density
+    subroutine test_pbe_c_zero_density(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: eps_c, vrho, vsigma
+
+        call pbe_correlation(0.0_wp, 0.0_wp, eps_c, vrho, vsigma)
+
+        if (eps_c /= 0.0_wp .or. vrho /= 0.0_wp .or. vsigma /= 0.0_wp) then
+            write (*, '(a)') 'FAIL test_pbe_c_zero_density'
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_pbe_c_zero_density'
+        end if
+    end subroutine test_pbe_c_zero_density
+
+!> PBE correlation with sigma=0 should reduce to PW92
+    subroutine test_pbe_c_lda_limit(passed)
+        use xc, only: pw92_correlation
+        logical, intent(inout) :: passed
+        real(wp) :: rho, eps_c, vrho, vsigma
+        real(wp) :: e0, v0, rel_err_e, rel_err_v
+
+        rho = 0.1_wp
+        call pbe_correlation(rho, 0.0_wp, eps_c, vrho, vsigma)
+        call pw92_correlation(rho, e0, v0)
+
+        rel_err_e = abs(eps_c - e0)/abs(e0)
+        rel_err_v = abs(vrho - v0)/abs(v0)
+
+        if (rel_err_e > 1.0e-12_wp .or. rel_err_v > 1.0e-12_wp) then
+            write (*, '(a,2es12.5)') 'FAIL test_pbe_c_lda_limit  err=', &
+                rel_err_e, rel_err_v
+            passed = .false.
+        else
+            write (*, '(a)') 'PASS test_pbe_c_lda_limit'
+        end if
+    end subroutine test_pbe_c_lda_limit
+
+!> verify PBE correlation potential and vsigma by numerical differentiation
+    subroutine test_pbe_c_potential_numerical(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: rho, sigma, h
+        real(wp) :: eps_c, vrho, vsigma
+        real(wp) :: eps_p, vr_p, vs_p, eps_m, vr_m, vs_m
+        real(wp) :: vrho_num, vsigma_num, rel_err_rho, rel_err_sigma
+
+        rho   = 0.1_wp
+        sigma = 0.01_wp
+        h     = 1.0e-6_wp
+
+        call pbe_correlation(rho, sigma, eps_c, vrho, vsigma)
+
+        call pbe_correlation(rho + h, sigma, eps_p, vr_p, vs_p)
+        call pbe_correlation(rho - h, sigma, eps_m, vr_m, vs_m)
+        vrho_num = ((rho + h)*eps_p - (rho - h)*eps_m)/(2.0_wp*h)
+        rel_err_rho = abs(vrho - vrho_num)/abs(vrho)
+
+        call pbe_correlation(rho, sigma + h, eps_p, vr_p, vs_p)
+        call pbe_correlation(rho, sigma - h, eps_m, vr_m, vs_m)
+        vsigma_num = (rho*eps_p - rho*eps_m)/(2.0_wp*h)
+        rel_err_sigma = abs(vsigma - vsigma_num)/abs(vsigma)
+
+        if (rel_err_rho > 1.0e-5_wp .or. rel_err_sigma > 1.0e-5_wp) then
+            write (*, '(a,2es12.5)') &
+                'FAIL test_pbe_c_potential_numerical  err=', &
+                rel_err_rho, rel_err_sigma
+            passed = .false.
+        else
+            write (*, '(a,2es8.1)') &
+                'PASS test_pbe_c_potential_numerical  rel_err=', &
+                rel_err_rho, rel_err_sigma
+        end if
+    end subroutine test_pbe_c_potential_numerical
+
+!> compare PBE correlation against libxc reference data (test/refs/gga_c_pbe.data)
+    subroutine test_pbe_c_libxc(passed)
+        logical, intent(inout) :: passed
+        real(wp), parameter :: tol = 1.0e-11_wp
+
+        ! rhoa=1.7, sigma~0 (LDA limit)
+        call check_gga_ref(passed, 'pbe_c_libxc rho=3.40  sig~0  ', 'c', &
+            1.7_wp, 0.81e-11_wp, &
+            -0.277343302026e+00_wp, -0.902545684170e-01_wp, &
+            0.828329874208e-03_wp, 0.165665974842e-02_wp, 0.828329874208e-03_wp, tol)
+
+        ! rhoa=1.7, sigmaaa=1.7
+        call check_gga_ref(passed, 'pbe_c_libxc rho=3.40  sig=6.8', 'c', &
+            1.7_wp, 1.7_wp, &
+            -0.271855691853e+00_wp, -0.923103473041e-01_wp, &
+            0.786385334368e-03_wp, 0.157277066874e-02_wp, 0.786385334368e-03_wp, tol)
+
+        ! rhoa=1.5, sigmaaa=36
+        call check_gga_ref(passed, 'pbe_c_libxc rho=3.00  sig=144', 'c', &
+            1.5_wp, 36.0_wp, &
+            -0.156330536080e+00_wp, -0.102948996370e+00_wp, &
+            0.378004824716e-03_wp, 0.756009649433e-03_wp, 0.378004824716e-03_wp, tol)
+
+        ! rhoa=0.088, sigmaaa=0.087 (low density)
+        call check_gga_ref(passed, 'pbe_c_libxc rho=0.176 sig=0.3', 'c', &
+            0.088_wp, 0.087_wp, &
+            -0.353114293615e-02_wp, -0.644123523321e-01_wp, &
+            0.830804942063e-02_wp, 0.166160988413e-01_wp, 0.830804942063e-02_wp, tol)
+
+        ! rhoa=0.26, sigmaaa=0.28
+        call check_gga_ref(passed, 'pbe_c_libxc rho=0.52  sig=1.1', 'c', &
+            0.26_wp, 0.28_wp, &
+            -0.257202574589e-01_wp, -0.866997760784e-01_wp, &
+            0.582853357983e-02_wp, 0.116570671597e-01_wp, 0.582853357983e-02_wp, tol)
+
+        ! rhoa=1800, sigmaaa=0.55 (high density)
+        call check_gga_ref(passed, 'pbe_c_libxc rho=3600  sig=2.2', 'c', &
+            1800.0_wp, 0.55_wp, &
+            -0.531558156901e+03_wp, -0.157670707589e+00_wp, &
+            0.767547413336e-07_wp, 0.153509482667e-06_wp, 0.767547413336e-07_wp, tol)
+    end subroutine test_pbe_c_libxc
+
+end program test_xc


### PR DESCRIPTION
### Theory sections

- Kohn-Sham DFT introduction with correct energy expressions, including `E_nuc`
- Numerical integration and grid usage
- XC functionals:
  - LDA, Slater exchange plus VWN5 correlation
  - PBE, exchange plus correlation
- GGA matrix formula using `f(\rho,\sigma)` notation consistent with the code
- Kohn--Sham matrix formation
- Bonus section on hybrid DFT with PBE0

### New Exercises

- **Ex 21** — Grid generation, density integration, electron count verification
- **Ex 22** — Implement Slater exchange `\varepsilon_x` and `v_x`; combine with provided VWN5; verify against libxc reference table
- **Ex 23** — Basis function gradients, `\nabla \rho`, reduced density gradient `s`; finite-difference verification
- **Ex 24** — Build KS matrix, first LDA then GGA; compute KS energy; run LDA and PBE; generate a dissociation curve; compare against ORCA reference energies
- **Ex 25 (Bonus)** — Implement PBE0 hybrid with 25% HF exchange

### Pedagogical split

#### Students implement:

- Slater exchange
- Density and gradient evaluation
- KS matrix assembly
- SCF loop modification

#### Provided by us:

- VWN5
- PW92
- PBE-X
- PBE-C
- Molecular integration grid in `src/grid.f90`

### Added SCF Reference Energies

Molecules: `H2`,`He`, `Be`, and `LiH`.  Methods:`LDA` (VWN5), `PBE`, `PBE0`. Settings: `STO-3G` basis, `TightSCF`,`NoRI`.

## Implementation

### `src/xc.f90` -- XC functional module
Implemented four spin-restricted XC functional routines:

- `vwn5_correlation` — VWN-5 LDA correlation energy density and potential
- `pw92_correlation` — PW92 LDA correlation, used internally by PBE correlation
- `pbe_exchange` — PBE GGA exchange energy density, `vrho`, and `vsigma`
- `pbe_correlation` — PBE GGA correlation energy density, `vrho`, and `vsigma`

All routines return `d(\rho \varepsilon)/d\rho` and `d(\rho \varepsilon)/d\sigma` directly, matching the GGA matrix formula in the docs.

Added tests to `test/test_xc.f90`:

- Zero-density guard tests, ensuring no division by zero
- Numerical derivative checks, comparing finite-difference and analytical derivatives
- LDA limit tests, verifying that PBE reduces to LDA as `\sigma \to 0`
- Libxc reference comparison tests using data from `test/refs/` with relative tolerance `1e-11`

### `src/grid.f90` -- Molecular Grids

Implemented molecular grids with Becke partitioning. Angular Lebedev levels `230`, `434`, and `1202`. Radial points are adaptively constructed using covalent radii. The Angular and radial levels can be force-set optionally.

Addes tests (`test/test_grid.f90`) and verified the implementation using sanity checks (grid sizes, weights), tested integration results for single and two atom Gaussians for various grid levels.